### PR TITLE
Redirect to story url

### DIFF
--- a/src/components/StoryList/Item.jsx
+++ b/src/components/StoryList/Item.jsx
@@ -14,7 +14,7 @@ const StoryListItem = ({
   advertiser,
   publishedAt,
 }) => (
-  <Link as={`/${path}`} href={`/story?id=${id}`} passHref>
+  <Link as={`/${path.replace(/^\//, '')}`} href={`/story?id=${id}`} passHref>
     <ListGroupItem tag="a" href="#" className="flex-column align-items-start" action>
       <div className="d-flex flex-row justify-content-between">
         <div className="d-flex flex-row">

--- a/src/pages/story.jsx
+++ b/src/pages/story.jsx
@@ -11,6 +11,7 @@ import StoryView from '../components/StoryView';
 
 import pageQuery from '../gql/queries/pages/story.graphql';
 
+const { NODE_ENV } = process.env;
 const { log } = console;
 
 class Story extends Component {
@@ -74,7 +75,7 @@ class Story extends Component {
             kv,
           ].join(''), '');
         const toUrl = `${url}${queryString}`;
-        if (requestUrl.includes('localhost')) {
+        if (NODE_ENV !== 'production') {
           log('Aborting redirect! In production, this page would redirect to ', toUrl);
         } else {
           res.redirect(301, toUrl);
@@ -84,7 +85,7 @@ class Story extends Component {
       const requestUrl = `${window.location.href}`.split('?', 1)[0];
       if (url !== requestUrl) {
         const toUrl = url + window.location.search;
-        if (requestUrl.includes('localhost')) {
+        if (NODE_ENV !== 'production' || requestUrl.includes('localhost')) {
           log('Aborting redirect! In production, this page would redirect to ', toUrl);
         } else {
           window.location.href = toUrl;

--- a/src/pages/story.jsx
+++ b/src/pages/story.jsx
@@ -85,7 +85,7 @@ class Story extends Component {
       const requestUrl = `${window.location.href}`.split('?', 1)[0];
       if (url !== requestUrl) {
         const toUrl = url + window.location.search;
-        if (NODE_ENV !== 'production' || requestUrl.includes('localhost')) {
+        if (NODE_ENV !== 'production') {
           log('Aborting redirect! In production, this page would redirect to ', toUrl);
         } else {
           window.location.href = toUrl;


### PR DESCRIPTION
When visiting a story on the react app, check the published story's URL. If it does not match (and we're not in a development environment) redirect to the expected url. On dev, emit a notice about the expected redirect.

In practice:
When visiting http://localhost:3005/story/test-advertiser/test/5df94374466a9400015d4862 the developer will be warned (via the terminal or browser console, depending on whether the navigation was server- or client-side, respectively) that the redirect was aborted.

When visiting https://example.stories.native-x.parameter1.com and clicking on the test story, the browser will redirect (client-side) to the expected story url.

When visiting https://example.stories.native-x.parameter1.com/story/test-advertiser/test/5df94374466a9400015d4862, the browser will receive a 301 to the expected story url (https://www.test.com/sponsored/5df94374466a9400015d4862).