### PR TITLE
Fix trust and query string

### DIFF
--- a/src/pages/story.jsx
+++ b/src/pages/story.jsx
@@ -63,7 +63,7 @@ class Story extends Component {
     // Check for and redirect to canonical url
     const { url } = publishedStory;
     if (req) { // Only run on backend requests
-      const requestUrl = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+      const requestUrl = `${req.protocol}://${req.get('host')}${req.baseUrl}${req.path}`;
       if (url !== requestUrl) {
         // Build backend equivalent of `window.location.search` (?foo=bar&bat=baz)
         const queryString = Object.keys(req.query)

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,6 +7,7 @@ const { PORT } = env;
 
 const server = express();
 server.use(helmet());
+server.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
 
 module.exports = (client) => {
   const handle = client.getRequestHandler();


### PR DESCRIPTION
Resolves two issues with #1 after prod deployment:
- [x] Ensure that the local addresses are trusted for `req.protocol` to work correctly (retrieving from x-forwarded-proto)
- [x] Do not use the `originalPath` when comparing the express url with the story url. Use the `baseUrl`/`path` props to ignore query/hash parameters.